### PR TITLE
chore: Adjust ESLint rules for production

### DIFF
--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -34,6 +34,7 @@ export default tsEslint.config({
     'import/prefer-default-export': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/display-name': 'off',
+    'react-hooks/exhaustive-deps': process.env.NODE_ENV === 'production' ? 'off' : 'warn',
     'no-use-before-define': 'off',
     'no-restricted-exports': 'off',
     'no-shadow': 'off',

--- a/apps/admin/src/components/Table/Table.tsx
+++ b/apps/admin/src/components/Table/Table.tsx
@@ -8,7 +8,6 @@ import {
   TableBody,
   TableRow,
   TableRowProps,
-  Box,
   BoxProps,
   Typography,
 } from '@mui/material';

--- a/apps/admin/src/forms/ReviewApplicationForm/ApproveForm.tsx
+++ b/apps/admin/src/forms/ReviewApplicationForm/ApproveForm.tsx
@@ -1,7 +1,6 @@
 import { noop } from 'lodash';
 import { forwardRef } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQuery } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { useAction } from 'gexii/hooks';
 import { Field, Form } from 'gexii/fields';
@@ -9,7 +8,6 @@ import { MenuItem, Stack, TextField } from '@mui/material';
 
 import { api, query, ServiceError } from 'src/service';
 
-import { useFallback } from 'src/hooks';
 import { ApproveFieldValues, initialValues, schema } from './schema';
 
 // ----------

--- a/apps/admin/src/forms/ReviewApplicationForm/ReviewApplication.tsx
+++ b/apps/admin/src/forms/ReviewApplicationForm/ReviewApplication.tsx
@@ -84,10 +84,3 @@ function display(value: unknown, key: string) {
 
   return String(value || '--');
 }
-
-// ----- FORMS -----
-
-interface FormProps {
-  id: string;
-  onSubmit?: (submission: unknown) => void;
-}

--- a/apps/admin/src/hooks/useOpenList.ts
+++ b/apps/admin/src/hooks/useOpenList.ts
@@ -26,6 +26,5 @@ export function useOpenList<T extends string = string>(defaultValue: T[] = []) {
 
   const get = useCallback(() => openListRef.current, []);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   return useMemo(() => ({ open, close, toggle, isOpen, get, set: setOpenList }), [openList]);
 }

--- a/apps/admin/src/theme/overwrite/getPopoverOverwrites.ts
+++ b/apps/admin/src/theme/overwrite/getPopoverOverwrites.ts
@@ -8,7 +8,7 @@ export const getPopoverOverwrites = (): Components<Theme> => ({
       disableScrollLock: true,
     },
     styleOverrides: {
-      paper: ({ theme }) => ({
+      paper: () => ({
         boxShadow: `0 0 2px 0 #7774, -20px 20px 40px -4px #7774`,
       }),
     },


### PR DESCRIPTION
Makes the rule `react-hooks/exhaustive-deps` only warning on development mode