### PR TITLE
Feat: Add PDF Upload Field to Portfolio Page

### DIFF
--- a/apps/admin/src/forms/PortfolioForm/PortfolioForm.tsx
+++ b/apps/admin/src/forms/PortfolioForm/PortfolioForm.tsx
@@ -38,7 +38,8 @@ export default forwardRef(function PortfolioForm(
   const resolveUnsyncedMedia = useAction(async () => {
     const values = methods.getValues();
     await resolveMedia.byPath(values, 'opening.avatar');
-    await resolveMedia.byPath(values, 'opening.cv');
+    await resolveMedia.byPath(values, 'opening.cv.doc');
+    await resolveMedia.byPath(values, 'opening.cv.pdf');
     await resolveMedia.list(
       values.selectionOfIdeas.items
         .map((item) => item.img as DataType.UnsyncedMediaDto)
@@ -77,8 +78,13 @@ export default forwardRef(function PortfolioForm(
           </Field>
         </Grid>
         <Grid>
-          <Field label="CV" name="opening.cv">
-            <DocumentField />
+          <Field label="CV (doc)" name="opening.cv.doc">
+            <DocumentField accept="application/document,.doc,.docx" />
+          </Field>
+        </Grid>
+        <Grid>
+          <Field label="CV (pdf)" name="opening.cv.pdf">
+            <DocumentField accept="application/pdf" />
           </Field>
         </Grid>
       </Grid>

--- a/apps/admin/src/forms/PortfolioForm/schema.ts
+++ b/apps/admin/src/forms/PortfolioForm/schema.ts
@@ -14,7 +14,10 @@ export const initialValues: FieldValues = {
     title: '',
     subtitle: '',
     avatar: null as never,
-    cv: null as never,
+    cv: {
+      doc: null as never,
+      pdf: null as never,
+    },
   },
   selectionOfWorks: {
     title: '',

--- a/apps/service/src/projects/portfolio/portfolio.service.ts
+++ b/apps/service/src/projects/portfolio/portfolio.service.ts
@@ -62,7 +62,8 @@ export class PortfolioService {
 
   private findRelatedMedias = (updatePortfolioDto: UpdatePortfolioDto) => {
     return [
-      updatePortfolioDto.opening.cv,
+      updatePortfolioDto.opening.cv.doc,
+      updatePortfolioDto.opening.cv.pdf,
       updatePortfolioDto.opening.avatar,
       ...updatePortfolioDto.selectionOfWorks.items
         .concat(updatePortfolioDto.selectionOfIdeas.items)

--- a/apps/service/src/projects/portfolio/transformer.service.ts
+++ b/apps/service/src/projects/portfolio/transformer.service.ts
@@ -40,7 +40,10 @@ export class TransformerService {
       opening: {
         ...data.opening,
         avatar: mediaMap[data.opening.avatar.id],
-        cv: mediaMap[data.opening.cv.id],
+        cv: {
+          doc: mediaMap[data.opening.cv.doc?.id],
+          pdf: mediaMap[data.opening.cv.pdf?.id],
+        },
       },
       selectionOfWorks: {
         ...data.selectionOfWorks,

--- a/packages/core/src/data/portfolio.data.dto.ts
+++ b/packages/core/src/data/portfolio.data.dto.ts
@@ -18,7 +18,10 @@ export namespace Portfolio {
 
   export interface OpeningDto extends Portfolio.SectionDto {
     avatar: MediaDto;
-    cv: MediaDto;
+    cv: {
+      doc: MediaDto;
+      pdf: MediaDto;
+    };
   }
 
   export interface SelectionDto extends Portfolio.SectionDto {

--- a/packages/core/src/dto/portfolio.dto.ts
+++ b/packages/core/src/dto/portfolio.dto.ts
@@ -17,7 +17,10 @@ export class UpdatePortfolioOpeningDto extends createZodDto(
   UpdatePortfolioSectionDto.schema.and(
     z.object({
       avatar: z.entities.media(),
-      cv: z.entities.media(),
+      cv: z.object({
+        doc: z.entities.media(),
+        pdf: z.entities.media(),
+      }),
     }),
   ),
 ) {}

--- a/packages/ui/src/components/UploadField/ImageField.tsx
+++ b/packages/ui/src/components/UploadField/ImageField.tsx
@@ -37,7 +37,6 @@ export function ImageField({ error, value, height, width, ...props }: ImageField
       )}
 
       <Stack
-        height="100%"
         alignItems="center"
         justifyContent="center"
         spacing={0.5}
@@ -84,26 +83,13 @@ const BackgroundImage = styled(Image)(() => ({
 // ----- MIXINS -----
 
 const showContentOnHover: SystemStyleObject<Theme> = {
-  zIndex: 2,
-
-  '& > *': {
-    zIndex: 2,
-    opacity: 0,
-    transition: (theme) => theme.transitions.create('opacity'),
-  },
-  '&:hover > *, &:hover::before': {
-    opacity: 1,
-  },
-  '&::before': {
-    content: '""',
-    display: 'block',
-    height: '100%',
-    width: '100%',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    opacity: 0,
-    background: '#0007',
-    transition: (theme) => theme.transitions.create('opacity'),
-  },
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  opacity: 0,
+  height: '100%',
+  width: '100%',
+  background: '#0007',
+  transition: (theme) => theme.transitions.create('opacity'),
+  '&:hover': { opacity: 1 },
 };


### PR DESCRIPTION
Currently, the portfolio page only supports uploading a single CV file in `.docx` format. However, many users or clients may prefer viewing or sharing CVs in `.pdf` format.

## Problem  
- Only one file (for `.docx` CV) can be uploaded.
- There’s no option to upload a one more CV (`.pdf` version).

## Proposed Solution  
Add a new field to the portfolio page that allows users to upload a **PDF version of their CV** in addition to the existing DOCX field.

## Expected Outcome
- Users can upload both `.docx` and `.pdf` versions of their CV.
- Portfolio viewers (or admin) can choose to download either version.

## Additional Notes
- Make sure file type restrictions are enforced on both client and server.
- Reuse existing file upload components if possible.
